### PR TITLE
Sass gem global installation

### DIFF
--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -3,6 +3,7 @@
   become: yes
 
 - name: Install gems
-  gem: name={{ item }} state=latest
+  gem: name={{ item }} state=latest user_install=no
+  sudo: yes
   with_items:
     - sass


### PR DESCRIPTION
Default value of  `user_install` option set to `yes` so we can't execute `sass` command in shell
